### PR TITLE
fix(flow): update react component state on angular input changes

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,5 @@
+<button style="position: absolute;z-index: 10" (click)="addNode()">Add node</button>
+
 <ngx-xyflow
     [nodes]="nodes"
     [edges]="edges"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -75,4 +75,19 @@ export class AppComponent {
         console.log(data)
     }
 
+    addNode() {
+        const nodeCount = this.nodes.length;
+        const id = (nodeCount + 1).toString();
+
+        this.nodes = [
+            ...this.nodes,
+            {
+                id: id,
+                type: 'output',
+                data: { label: `New node ${id}` },
+                position: { x: 650 , y: (nodeCount * 100) },
+                targetPosition: 'left',
+            }
+        ];
+    }
 }

--- a/src/xyflow/background.directive.ts
+++ b/src/xyflow/background.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import {Directive, Input, SimpleChanges} from '@angular/core';
 import { BackgroundProps } from '@xyflow/react';
 import { XYFlowComponent } from './xyflow.component';
 
@@ -20,7 +20,7 @@ export class BackgroundDirective implements BackgroundProps {
     @Input() variant: BackgroundProps['variant'];
 
     constructor(private readonly xyflow: XYFlowComponent) {}
-    ngOnChanges() {
-        this.xyflow.ngOnChanges();
+    ngOnChanges(changes: SimpleChanges) {
+        this.xyflow.ngOnChanges(changes);
     }
 }

--- a/src/xyflow/controls.directive.ts
+++ b/src/xyflow/controls.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, EventEmitter, Input, Output } from '@angular/core';
+import {Directive, EventEmitter, Input, Output, SimpleChanges} from '@angular/core';
 import { ControlProps } from '@xyflow/react';
 import { XYFlowComponent } from './xyflow.component';
 
@@ -24,7 +24,7 @@ export class ControlsDirective implements Omit<ControlProps, 'onFitView' | 'onIn
     @Output() onZoomOut = new EventEmitter<Parameters<ControlProps['onZoomOut']>>();
 
     constructor(private readonly xyflow: XYFlowComponent) { }
-    ngOnChanges() {
-        this.xyflow.ngOnChanges();
+    ngOnChanges(changes: SimpleChanges) {
+        this.xyflow.ngOnChanges(changes);
     }
 }

--- a/src/xyflow/handle.directive.ts
+++ b/src/xyflow/handle.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import {Directive, Input, SimpleChanges} from '@angular/core';
 import { HandleProps } from '@xyflow/react';
 import { XYFlowComponent } from './xyflow.component';
 
@@ -19,7 +19,7 @@ export class HandleDirective implements Omit<HandleProps, "position" | "onConnec
     // @Output() onEdgesDelete = new EventEmitter<[XYFlowProps['onEdgesDelete']]>
 
     constructor(private readonly xyflow: XYFlowComponent) { }
-    ngOnChanges() {
-        this.xyflow.ngOnChanges();
+    ngOnChanges(changes: SimpleChanges) {
+        this.xyflow.ngOnChanges(changes);
     }
 }

--- a/src/xyflow/minimap.directive.ts
+++ b/src/xyflow/minimap.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, EventEmitter, Input, Output } from '@angular/core';
+import {Directive, EventEmitter, Input, Output, SimpleChanges} from '@angular/core';
 import { MiniMapProps } from '@xyflow/react';
 import { XYFlowComponent } from './xyflow.component';
 
@@ -29,7 +29,7 @@ export class MinimapDirective implements Omit<MiniMapProps, 'onClick' | 'onNodeC
     @Output() onNodeClick = new EventEmitter<Parameters<MiniMapProps['onNodeClick']>>();
 
     constructor(private readonly xyflow: XYFlowComponent) { }
-    ngOnChanges() {
-        this.xyflow.ngOnChanges();
+    ngOnChanges(changes: SimpleChanges) {
+        this.xyflow.ngOnChanges(changes);
     }
 }

--- a/src/xyflow/node-resizer.directive.ts
+++ b/src/xyflow/node-resizer.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import {Directive, Input, SimpleChanges} from '@angular/core';
 import { NodeResizerProps } from '@xyflow/react';
 import { XYFlowComponent } from './xyflow.component';
 
@@ -26,7 +26,7 @@ export class NodeResizerDirective implements NodeResizerProps {
     @Input() onResizeEnd: NodeResizerProps['onResizeEnd'];
 
     constructor(private readonly xyflow: XYFlowComponent) { }
-    ngOnChanges() {
-        this.xyflow.ngOnChanges();
+    ngOnChanges(changes: SimpleChanges) {
+        this.xyflow.ngOnChanges(changes);
     }
 }

--- a/src/xyflow/node-toolbar.directive.ts
+++ b/src/xyflow/node-toolbar.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import {Directive, Input, SimpleChanges} from '@angular/core';
 import { NodeToolbarProps } from '@xyflow/react';
 import { XYFlowComponent } from './xyflow.component';
 
@@ -13,7 +13,7 @@ export class NodeToolbarDirective implements Omit<NodeToolbarProps, 'position'> 
     @Input() position: 'top' | 'left' | 'right' | 'bottom';
 
     constructor(private readonly xyflow: XYFlowComponent) { }
-    ngOnChanges() {
-        this.xyflow.ngOnChanges();
+    ngOnChanges(changes: SimpleChanges) {
+        this.xyflow.ngOnChanges(changes);
     }
 }

--- a/src/xyflow/node.directive.ts
+++ b/src/xyflow/node.directive.ts
@@ -1,5 +1,21 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { ApplicationRef, Component, ContentChild, ContentChildren, Directive, ElementRef, EventEmitter, Injector, Input, NgZone, Output, QueryList, TemplateRef, ViewChildren } from '@angular/core';
+import {
+    ApplicationRef,
+    Component,
+    ContentChild,
+    ContentChildren,
+    Directive,
+    ElementRef,
+    EventEmitter,
+    Injector,
+    Input,
+    NgZone,
+    Output,
+    QueryList,
+    SimpleChanges,
+    TemplateRef,
+    ViewChildren
+} from '@angular/core';
 import { ReactifyNgComponent, ReactifyAngularComponent } from 'ngx-reactify';
 import { Handle, NodeResizer, NodeToolbar } from '@xyflow/react';
 import * as React from 'react';
@@ -95,8 +111,8 @@ export class NodeDirective {
         private readonly ngZone: NgZone
     ) { }
 
-    ngOnChanges() {
-        this.xyflow.ngOnChanges();
+    ngOnChanges(changes: SimpleChanges) {
+        this.xyflow.ngOnChanges(changes);
     }
 
     ngAfterViewInit() {


### PR DESCRIPTION
- Store react setState functions in class properties
- Add useEffect hook to capture setters for ngOnChanges
- Update nodes and edges state when input properties change
- Maintain internal state while handling external updates

Fixes #2