### PR TITLE
xfix(node): pass full node context to template node wrappers

### DIFF
--- a/src/xyflow/node.directive.spec.ts
+++ b/src/xyflow/node.directive.spec.ts
@@ -1,7 +1,105 @@
+import { ApplicationRef, NgZone } from '@angular/core';
+import * as ngCore from '@angular/core';
+import * as React from 'react';
 import { NodeDirective } from './node.directive';
+import { XYFlowComponent } from './xyflow.component';
 
 describe('NodeDirective', () => {
     it('should be defined', () => {
         expect(NodeDirective).toBeDefined();
+    });
+
+    it('should register a template node wrapper when nodeType is provided', () => {
+        const xyflow = {
+            templateNodeTypes: {},
+            ngOnChanges: () => undefined,
+            _render: jasmine.createSpy('_render')
+        } as unknown as XYFlowComponent;
+
+        const appRef = {
+            injector: {},
+            attachView: jasmine.createSpy('attachView')
+        } as unknown as ApplicationRef;
+
+        const directive = new NodeDirective(
+            xyflow,
+            appRef,
+            {} as any,
+            {} as NgZone
+        );
+
+        directive.nodeType = 'switch-node';
+        directive.template = {} as any;
+
+        directive.ngAfterViewInit();
+
+        expect((xyflow as any).templateNodeTypes['switch-node']).toBeDefined();
+        expect((xyflow as any)._render).toHaveBeenCalled();
+    });
+
+    it('should pass full node props into the Angular node component', () => {
+        const xyflow = {
+            templateNodeTypes: {},
+            ngOnChanges: () => undefined,
+            _render: jasmine.createSpy('_render')
+        } as unknown as XYFlowComponent;
+
+        const appRef = {
+            injector: {},
+            attachView: jasmine.createSpy('attachView')
+        } as unknown as ApplicationRef;
+
+        const directive = new NodeDirective(
+            xyflow,
+            appRef,
+            {} as any,
+            {} as NgZone
+        );
+
+        directive.nodeType = 'switch-node';
+        directive.template = {} as any;
+
+        const componentRef = {
+            setInput: jasmine.createSpy('setInput'),
+            hostView: {},
+            changeDetectorRef: {
+                detectChanges: jasmine.createSpy('detectChanges')
+            },
+            destroy: jasmine.createSpy('destroy')
+        } as any;
+
+        const createComponentSpy = spyOn(ngCore, 'createComponent').and.returnValue(componentRef);
+
+        spyOn(React, 'memo').and.callFake((factory: any) => factory);
+
+        const firstRef = { current: {} };
+        const secondRef = { current: null };
+        let refCalls = 0;
+
+        spyOn(React, 'useRef').and.callFake(() => {
+            refCalls += 1;
+            return refCalls === 1 ? firstRef : secondRef;
+        });
+
+        spyOn(React, 'useEffect').and.callFake((effect: any) => {
+            effect();
+        });
+
+        directive.ngAfterViewInit();
+
+        const wrapper = (xyflow as any).templateNodeTypes['switch-node'];
+        const nodeProps = {
+            id: 'n-1',
+            type: 'switch-node',
+            data: { label: 'Switch', routeCount: 3 },
+            position: { x: 10, y: 20 }
+        };
+
+        wrapper(nodeProps);
+
+        expect(createComponentSpy).toHaveBeenCalled();
+        expect(componentRef.setInput).toHaveBeenCalledWith('template', directive.template);
+        expect(componentRef.setInput).toHaveBeenCalledWith('data', nodeProps.data);
+        expect(componentRef.setInput).toHaveBeenCalledWith('node', nodeProps);
     });
 });

--- a/src/xyflow/node.directive.ts
+++ b/src/xyflow/node.directive.ts
@@ -32,7 +32,7 @@ import { XYFlowComponent } from './xyflow.component';
             @if(template) {
                 <ng-container
                     [ngTemplateOutlet]="template"
-                    [ngTemplateOutletContext]="{ '$implicit': data }"
+                    [ngTemplateOutletContext]="{ '$implicit': node, 'node': node, 'data': data }"
                 />
             }
         </div>
@@ -115,7 +115,8 @@ export class NodeDirective {
         }
 
         // Manual Wrapper to bypass ngx-reactify issues
-        const ManualWrapper = React.memo(({ data }: any) => {
+        const ManualWrapper = React.memo((props: any) => {
+            const { data } = props;
             const domRef = React.useRef(null);
             const compRef = React.useRef<any>(null);
 
@@ -130,6 +131,7 @@ export class NodeDirective {
 
                 ref.setInput('template', this.template);
                 ref.setInput('data', data);
+                ref.setInput('node', props);
 
                 this.appRef.attachView(ref.hostView);
                 ref.changeDetectorRef.detectChanges();
@@ -144,9 +146,10 @@ export class NodeDirective {
             React.useEffect(() => {
                 if (compRef.current) {
                     compRef.current.setInput('data', data);
+                    compRef.current.setInput('node', props);
                     compRef.current.changeDetectorRef.detectChanges();
                 }
-            }, [data]);
+            }, [props]);
 
             // Render Handles, Resizer, Toolbar
             const handles = this.handles ? this.handles.map(handle => {


### PR DESCRIPTION
Summary:
This PR fixes Angular custom node template context consistency by passing the full node object, not only node data.
Problem
In advanced custom nodes (including switch/case style branching), templates often need access to full node metadata for dynamic handle rendering and conditional UI logic.
Previously, template context and wrapper updates could miss full node props.

Changes:
Set template context to include:
$implicit: node
node: node
data: data
Pass node props to XYFlowNodeComponent on mount.
Update node props on wrapper rerender.

Files changed:
src/xyflow/node.directive.ts

Validation
Angular package build succeeds locally with npm run build.
Existing behavior for data binding is preserved, with additional node context availability for advanced node scenarios.